### PR TITLE
adds deregistration_delay for lb-fargate-svc

### DIFF
--- a/loadbalanced-fargate-svc/loadbalanced-fargate-svc/v1/instance_infrastructure/cloudformation.yaml
+++ b/loadbalanced-fargate-svc/loadbalanced-fargate-svc/v1/instance_infrastructure/cloudformation.yaml
@@ -102,6 +102,9 @@ Resources:
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId: '{{environment.outputs.VpcId}}'
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: '30'
 
   # Create a rule on the load balancer for routing traffic to the target group
   LoadBalancerRule:


### PR DESCRIPTION
This significantly speeds up rolling deployments which is useful when experimenting/demonstrating proton pipelines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
